### PR TITLE
Replace createlang call with psql command

### DIFF
--- a/linkedgeodata-cli/bin/lgd-createdb.sh
+++ b/linkedgeodata-cli/bin/lgd-createdb.sh
@@ -200,9 +200,7 @@ fi
 
 
 createdb -h "$dbHost" -U "$dbUser" "$dbName"
-createlang -h "$dbHost" -U "$dbUser" plpgsql "$dbName"
-psql -h "$dbHost" -U "$dbUser" -d"$dbName" -f "$postgisPath/postgis.sql"
-psql -h "$dbHost" -U "$dbUser" -d"$dbName" -f "$postgisPath/spatial_ref_sys.sql"
+psql -h "$dbHost" -U "$dbUser" -d "$dbName" -c "CREATE EXTENSION postgis;"
 
 psql -h "$dbHost" -U "$dbUser" -d"$dbName" -f"$osmosisSqlPath/pgsimple_schema_0.6.sql"
 psql -h "$dbHost" -U "$dbUser" -d"$dbName" -f"$osmosisSqlPath/pgsimple_schema_0.6_linestring.sql"


### PR DESCRIPTION
The `createlang` call shouldn't really work anymore on current systems and is thus replaced.